### PR TITLE
Fix mobile viewport overflow issue

### DIFF
--- a/src/assets/Components/Landing.jsx
+++ b/src/assets/Components/Landing.jsx
@@ -442,8 +442,8 @@ function Landing() {
 
   {mobileMenuOpen && typeof document !== 'undefined' && createPortal(
     <div
-      className="md:hidden fixed left-0 top-0 z-[2147483650] w-[100vw] bg-gradient-to-br from-white/5 via-white/3 to-white/2 backdrop-blur-lg backdrop-saturate-150 border border-white/10 shadow-2xl"
-      style={{ height: 'calc(var(--vh, 1vh) * 100)', paddingTop: 'env(safe-area-inset-top, 0px)', paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      className="md:hidden fixed inset-0 z-[2147483650] bg-gradient-to-br from-white/5 via-white/3 to-white/2 backdrop-blur-lg backdrop-saturate-150 border border-white/10 shadow-2xl"
+      style={{ paddingTop: 'env(safe-area-inset-top, 0px)', paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
       onClick={() => setMobileMenuOpen(false)}
     >
       <div className="relative w-full h-full" onClick={(e) => e.stopPropagation()}>

--- a/src/assets/Components/Loader.jsx
+++ b/src/assets/Components/Loader.jsx
@@ -95,10 +95,9 @@ const Loader = ({ onComplete } = {}) => {
 
   const containerStyle = {
     position: 'fixed',
-    left: 0,
-    top: 0,
-    width: '100vw',
-    height: 'calc(var(--vh, 1vh) * 100)',
+    inset: 0,
+    width: 'auto',
+    height: 'auto',
     paddingTop: 'env(safe-area-inset-top, 0px)',
     paddingBottom: 'env(safe-area-inset-bottom, 0px)',
     background: '#212427',

--- a/src/index.css
+++ b/src/index.css
@@ -83,3 +83,7 @@ html, body {
     height: 100%;
     margin: 0;
 }
+
+/* NEW: make layout robust on mobile to avoid horizontal overflow */
+*, *::before, *::after { box-sizing: border-box; }
+html, body, #root { max-width: 100%; overflow-x: clip; }


### PR DESCRIPTION
Fixes mobile horizontal overflow and the resulting extra width by applying global CSS and updating viewport-relative units.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d305f5c-03ed-48a9-9cac-d1d76ae3a05c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d305f5c-03ed-48a9-9cac-d1d76ae3a05c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

